### PR TITLE
Add CLI opts for frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,31 +21,46 @@ Usage: markdown-to-medium <path to markdown>
 Options:
   -h, --help        Output usage information
   -v, --version     Output version number
-  -t, --token       Pass in the user token, stored after first use
+  -t, --token       Pass in the user token
+  -i, --id          Pass in the user id
+  -u, --canonicalUrl  Add a cross-reference to the original url for post
+  --title           Pass in the title
+  --tags            Pass in tags
 
 Examples:
-  $ markdown-to-medium ./foobar.md   # Publish markdown to medium
+  $ markdown-to-medium ./foobar.md
+  # Publish markdown to medium
+
+  $ markdown-to-medium ./foobar.md  --tags={tag1,tag2} --title="Hello world"
+  # Publish markdown to medium
 
 Docs: https://github.com/yoshuawuyts/markdown-to-medium
 Bugs: https://github.com/yoshuawuyts/markdown-to-medium/issues
 ```
 
-## Meta data
-To get the correct title and date to show up, use `YAML` frontmatter in your
-markdown:
+## Metadata
+
+To get the correct title and date to show up without using options, you can
+use `YAML` frontmatter in your markdown:
+
 ```md
 ---
 title: 'How to light a tire fire'
 created: '6-20-2016'
+canonicalUrl: 'https://example.com/how-to-light-a-tire-fire'
+tags: ['fire', 'tires']
 ---
 
 Now put some of the best words here.
 You can do it, you're witty and smart and charming and
 ```
 
+Note that `tags` and `canonicalUrl` are optional, and that `created` is not
+passed through to Medium.
+
 ## Installation
 ```sh
-$ npm install markdown-to-medium
+$ npm install --global markdown-to-medium
 ```
 
 ## See Also

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -21,7 +21,9 @@ const opts = cliclopts([
   { name: 'help', abbr: 'h', boolean: true },
   { name: 'version', abbr: 'v', boolean: true },
   { name: 'token', abbr: 't', string: true },
-  { name: 'canonicalUrl', abbr: 'u', string: true}
+  { name: 'canonicalUrl', abbr: 'u', string: true},
+  { name: 'title', string: true},
+  { name: 'tags', alias: ['tag']}
 ])
 
 const argv = minimist(process.argv.slice(2), opts.options())

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -5,9 +5,16 @@ Options:
   -v, --version     Output version number
   -t, --token       Pass in the user token
   -i, --id          Pass in the user id
+  -u, --canonicalUrl  Add a cross-reference to the original url for post
+  --title           Pass in the title
+  --tags            Pass in tags
 
 Examples:
-  $ markdown-to-medium ./foobar.md   # Publish markdown to medium
+  $ markdown-to-medium ./foobar.md
+  # Publish markdown to medium
+
+  $ markdown-to-medium ./foobar.md  --tags={tag1,tag2} --title="Hello world"
+  # Publish markdown to medium
 
 Docs: https://github.com/yoshuawuyts/markdown-to-medium
 Bugs: https://github.com/yoshuawuyts/markdown-to-medium/issues

--- a/index.js
+++ b/index.js
@@ -35,9 +35,9 @@ function main (options, done) {
   }
 
   const matter = frontMatter(src)
-  const title = matter.attributes.title
-  const tags = matter.attributes.tags
-  const canonicalUrl = options.canonicalUrl || ""
+  const title = options.title || matter.attributes.title
+  const tags = options.tags || matter.attributes.tags
+  const canonicalUrl = options.canonicalUrl || matter.attributes.canonicalUrl || ""
 
   let content = `
   # ${title}

--- a/test.md
+++ b/test.md
@@ -1,6 +1,7 @@
 ---
 title: 'How to light a tire fire'
 created: '6-20-2016'
+tags: ['fire', 'tires']
 ---
 
 Now put some of the best words here.


### PR DESCRIPTION
This adds CLI options for canonicalUrl, title, and tags, and adds canonicalUrl to frontmatter as an option. I also edited the documentation to show changes.

This closes #9 and #10, as it folds them in.