### PR TITLE
Fix adding tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Examples:
   $ markdown-to-medium ./foobar.md
   # Publish markdown to medium
 
-  $ markdown-to-medium ./foobar.md  --tags={tag1,tag2} --title="Hello world"
+  $ markdown-to-medium ./foobar.md  --tags="tag1,tag2" --title="Hello world"
   # Publish markdown to medium
 
 Docs: https://github.com/yoshuawuyts/markdown-to-medium

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -15,7 +15,7 @@ Examples:
   $ markdown-to-medium ./foobar.md
   # Publish markdown to medium
 
-  $ markdown-to-medium ./foobar.md  --tags={tag1,tag2} --title="Hello world"
+  $ markdown-to-medium ./foobar.md  --tags="tag1,tag2" --title="Hello world"
   # Publish markdown to medium
 
 Docs: https://github.com/yoshuawuyts/markdown-to-medium

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function main (options, done) {
 
   const matter = frontMatter(src)
   let title = options.title || matter.attributes.title
-  const tags = options.tags || matter.attributes.tags
+  const tags = (options.tags && options.tags.split(',')) || matter.attributes.tags
   const publication = options.publication || matter.attributes.publication
   const canonicalUrl = options.canonicalUrl || matter.attributes.canonicalUrl || ''
   const license = checkLicense(options.license || matter.attributes.license)


### PR DESCRIPTION
Currently when adding tags using `--tags`, the error following occurs `Error: Unexpected fields specified` from Medium API because a string is passed instead of an array. This PR fixes this, adding tags from the file (`matter.attributes.tags`) still works.

ping @RichardLitt @yoshuawuyts 